### PR TITLE
feat: HAR 1.2 loader + synthetic captures

### DIFF
--- a/src/ddf_toolkit/simulator/har_loader.py
+++ b/src/ddf_toolkit/simulator/har_loader.py
@@ -1,7 +1,215 @@
-"""HAR 1.2 loader — Sprint 1 stub."""
+"""HAR 1.2 loader — parse HAR files and expose request/response lookups.
+
+HAR (HTTP Archive) format: https://w3c.github.io/web-performance/specs/HAR/Overview.html
+"""
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
 
-def load_har(path: str) -> None:
-    raise NotImplementedError("HAR loader is planned for Sprint 1")
+
+@dataclass(frozen=True)
+class HARRequest:
+    method: str
+    url: str
+    headers: dict[str, str]
+    body: str
+    comment: str = ""
+
+
+@dataclass(frozen=True)
+class HARResponse:
+    status: int
+    headers: dict[str, str]
+    body: Any
+    body_raw: str = ""
+    comment: str = ""
+
+
+@dataclass(frozen=True)
+class HAREntry:
+    request: HARRequest
+    response: HARResponse
+    comment: str = ""
+    simulated_event: bool = False
+    event_delay_ms: int = 0
+
+
+class HARLoadError(Exception):
+    pass
+
+
+@dataclass
+class HARLoader:
+    """Load and index HAR entries for request/response lookup."""
+
+    entries: list[HAREntry] = field(default_factory=list)
+    source_path: str = ""
+
+    @classmethod
+    def from_file(cls, path: Path) -> HARLoader:
+        """Load a HAR file from disk."""
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            msg = f"Cannot read HAR file {path}: {e}"
+            raise HARLoadError(msg) from e
+
+        return cls.from_json(raw, source_path=str(path))
+
+    @classmethod
+    def from_json(cls, raw: str, source_path: str = "") -> HARLoader:
+        """Parse HAR JSON string."""
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            msg = f"Invalid JSON in HAR file: {e}"
+            raise HARLoadError(msg) from e
+
+        if "log" not in data:
+            msg = "HAR file missing 'log' key"
+            raise HARLoadError(msg)
+
+        log = data["log"]
+        if "entries" not in log:
+            msg = "HAR log missing 'entries' key"
+            raise HARLoadError(msg)
+
+        entries: list[HAREntry] = []
+        for i, entry_data in enumerate(log["entries"]):
+            try:
+                entries.append(_parse_entry(entry_data))
+            except (KeyError, TypeError) as e:
+                msg = f"Invalid HAR entry #{i}: {e}"
+                raise HARLoadError(msg) from e
+
+        return cls(entries=entries, source_path=source_path)
+
+    def match(
+        self,
+        method: str,
+        url: str,
+        *,
+        relaxed: bool = False,
+    ) -> HARResponse | None:
+        """Find a matching response for the given request.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            url: Full URL
+            relaxed: If True, match by path only (ignore query params)
+
+        Returns:
+            Matching HARResponse, or None if no match found.
+        """
+        method_upper = method.upper()
+
+        for entry in self.entries:
+            if entry.simulated_event:
+                continue
+            if entry.request.method.upper() != method_upper:
+                continue
+
+            if relaxed:
+                if _url_path(entry.request.url) == _url_path(url):
+                    return entry.response
+            else:
+                if _normalize_url(entry.request.url) == _normalize_url(url):
+                    return entry.response
+
+        return None
+
+    def event_entries(self) -> list[HAREntry]:
+        """Get entries marked as simulated events (for listener injection)."""
+        return [e for e in self.entries if e.simulated_event]
+
+    def list_entries(self) -> list[dict[str, str]]:
+        """List all entries as summary dicts (for CLI display)."""
+        result = []
+        for i, entry in enumerate(self.entries):
+            result.append(
+                {
+                    "index": str(i),
+                    "method": entry.request.method,
+                    "url": entry.request.url,
+                    "status": str(entry.response.status),
+                    "comment": entry.comment,
+                    "event": str(entry.simulated_event),
+                }
+            )
+        return result
+
+
+def _parse_entry(data: dict[str, Any]) -> HAREntry:
+    """Parse a single HAR entry."""
+    req_data = data["request"]
+    resp_data = data["response"]
+
+    # Request
+    headers = {}
+    for h in req_data.get("headers", []):
+        headers[h["name"]] = h["value"]
+
+    body = ""
+    if "postData" in req_data:
+        body = req_data["postData"].get("text", "")
+
+    request = HARRequest(
+        method=req_data["method"],
+        url=req_data["url"],
+        headers=headers,
+        body=body,
+        comment=req_data.get("comment", ""),
+    )
+
+    # Response
+    resp_headers = {}
+    for h in resp_data.get("headers", []):
+        resp_headers[h["name"]] = h["value"]
+
+    resp_body_raw = ""
+    resp_body: Any = None
+    content = resp_data.get("content", {})
+    if content.get("text"):
+        resp_body_raw = content["text"]
+        mime = content.get("mimeType", "")
+        if "json" in mime:
+            try:
+                resp_body = json.loads(resp_body_raw)
+            except json.JSONDecodeError:
+                resp_body = resp_body_raw
+        else:
+            resp_body = resp_body_raw
+
+    response = HARResponse(
+        status=resp_data["status"],
+        headers=resp_headers,
+        body=resp_body,
+        body_raw=resp_body_raw,
+        comment=resp_data.get("comment", ""),
+    )
+
+    return HAREntry(
+        request=request,
+        response=response,
+        comment=data.get("comment", ""),
+        simulated_event=data.get("_simulated_event", False),
+        event_delay_ms=data.get("_event_delay_ms", 0),
+    )
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize URL for comparison (lowercase scheme/host, sort query params)."""
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    sorted_query = "&".join(f"{k}={v[0]}" for k, v in sorted(params.items()))
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}?{sorted_query}".rstrip("?")
+
+
+def _url_path(url: str) -> str:
+    """Extract just the path from a URL."""
+    return urlparse(url).path

--- a/tests/fixtures/captures/microsoft_calendar_event_list.har
+++ b/tests/fixtures/captures/microsoft_calendar_event_list.har
@@ -1,0 +1,58 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "ddf-toolkit synthetic",
+      "version": "0.1.0",
+      "comment": "Synthetic HAR for Microsoft Calendar calendarView query"
+    },
+    "entries": [
+      {
+        "comment": "Current calendar view — returns 1 active event (meeting now)",
+        "request": {
+          "method": "GET",
+          "url": "https://graph.microsoft.com/v1.0/users/room1@contoso.com/calendarView?startdatetime=2026-04-25T10:00:00Z&enddatetime=2026-04-25T10:00:00Z&$select=subject,start,end&$count=true&$filter=isCancelled eq false&$top=1",
+          "headers": [
+            {"name": "Accept", "value": "application/json"},
+            {"name": "Prefer", "value": "outlook.timezone=Europe/Berlin"},
+            {"name": "Authorization", "value": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test-token-payload"}
+          ]
+        },
+        "response": {
+          "status": 200,
+          "headers": [
+            {"name": "Content-Type", "value": "application/json"}
+          ],
+          "content": {
+            "size": 500,
+            "mimeType": "application/json",
+            "text": "{\"@odata.count\":1,\"value\":[{\"subject\":\"Team Standup\",\"start\":{\"dateTime\":\"2026-04-25T09:30:00.0000000\",\"timeZone\":\"Europe/Berlin\"},\"end\":{\"dateTime\":\"2026-04-25T10:30:00.0000000\",\"timeZone\":\"Europe/Berlin\"}}]}"
+          }
+        }
+      },
+      {
+        "comment": "Future calendar view — returns 1 upcoming event",
+        "request": {
+          "method": "GET",
+          "url": "https://graph.microsoft.com/v1.0/users/room1@contoso.com/calendarView?startdatetime=2026-04-25T10:00:00Z&enddatetime=2026-04-25T16:00:00Z&$select=subject,start,end&$count=true&$filter=isCancelled eq false&$top=1&$orderby=start/dateTime asc",
+          "headers": [
+            {"name": "Accept", "value": "application/json"},
+            {"name": "Prefer", "value": "outlook.timezone=Europe/Berlin"},
+            {"name": "Authorization", "value": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test-token-payload"}
+          ]
+        },
+        "response": {
+          "status": 200,
+          "headers": [
+            {"name": "Content-Type", "value": "application/json"}
+          ],
+          "content": {
+            "size": 500,
+            "mimeType": "application/json",
+            "text": "{\"@odata.count\":1,\"value\":[{\"subject\":\"Sprint Review\",\"start\":{\"dateTime\":\"2026-04-25T14:00:00.0000000\",\"timeZone\":\"Europe/Berlin\"},\"end\":{\"dateTime\":\"2026-04-25T15:00:00.0000000\",\"timeZone\":\"Europe/Berlin\"}}]}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/captures/microsoft_calendar_oauth_flow.har
+++ b/tests/fixtures/captures/microsoft_calendar_oauth_flow.har
@@ -1,0 +1,59 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "ddf-toolkit synthetic",
+      "version": "0.1.0",
+      "comment": "Synthetic HAR for Microsoft Calendar OAuth client_credentials flow"
+    },
+    "entries": [
+      {
+        "comment": "OAuth token request — client_credentials grant to Azure AD",
+        "request": {
+          "method": "POST",
+          "url": "https://login.microsoftonline.com/tenant-id-here/oauth2/v2.0/token",
+          "headers": [
+            {"name": "Content-Type", "value": "application/x-www-form-urlencoded"}
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "client_id=test-client-id&client_secret=test-secret&scope=https://graph.microsoft.com/.default&grant_type=client_credentials"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": [
+            {"name": "Content-Type", "value": "application/json"}
+          ],
+          "content": {
+            "size": 1200,
+            "mimeType": "application/json",
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3600,\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test-token-payload\",\"ext_expires_in\":3600}"
+          }
+        }
+      },
+      {
+        "comment": "Get rooms/slaves list — authenticated request to Graph API",
+        "request": {
+          "method": "GET",
+          "url": "https://graph.microsoft.com/v1.0/places/microsoft.graph.room?$select=emailAddress",
+          "headers": [
+            {"name": "Accept", "value": "application/json"},
+            {"name": "Authorization", "value": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test-token-payload"}
+          ]
+        },
+        "response": {
+          "status": 200,
+          "headers": [
+            {"name": "Content-Type", "value": "application/json"}
+          ],
+          "content": {
+            "size": 350,
+            "mimeType": "application/json",
+            "text": "{\"value\":[{\"emailAddress\":\"room1@contoso.com\"},{\"emailAddress\":\"room2@contoso.com\"},{\"emailAddress\":\"room3@contoso.com\"}]}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/test_har_loader.py
+++ b/tests/unit/test_har_loader.py
@@ -1,0 +1,113 @@
+"""Tests for the HAR loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ddf_toolkit.simulator.har_loader import HARLoader, HARLoadError
+
+CAPTURES = Path(__file__).parent.parent / "fixtures" / "captures"
+
+
+class TestHARLoaderFromFile:
+    def test_load_oauth_flow(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        assert len(loader.entries) == 2
+        assert loader.entries[0].request.method == "POST"
+        assert loader.entries[1].request.method == "GET"
+
+    def test_load_event_list(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_event_list.har")
+        assert len(loader.entries) == 2
+
+    def test_load_nonexistent_file(self):
+        with pytest.raises(HARLoadError, match="Cannot read"):
+            HARLoader.from_file(Path("/nonexistent.har"))
+
+
+class TestHARLoaderFromJson:
+    def test_invalid_json(self):
+        with pytest.raises(HARLoadError, match="Invalid JSON"):
+            HARLoader.from_json("{broken")
+
+    def test_missing_log(self):
+        with pytest.raises(HARLoadError, match="missing 'log'"):
+            HARLoader.from_json('{"foo": "bar"}')
+
+    def test_missing_entries(self):
+        with pytest.raises(HARLoadError, match="missing 'entries'"):
+            HARLoader.from_json('{"log": {"version": "1.2"}}')
+
+
+class TestHARMatch:
+    @pytest.fixture()
+    def loader(self):
+        return HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+
+    def test_exact_match(self, loader):
+        resp = loader.match(
+            "POST",
+            "https://login.microsoftonline.com/tenant-id-here/oauth2/v2.0/token",
+        )
+        assert resp is not None
+        assert resp.status == 200
+        assert resp.body["token_type"] == "Bearer"
+
+    def test_no_match(self, loader):
+        resp = loader.match("GET", "https://example.com/nonexistent")
+        assert resp is None
+
+    def test_method_mismatch(self, loader):
+        resp = loader.match(
+            "GET",
+            "https://login.microsoftonline.com/tenant-id-here/oauth2/v2.0/token",
+        )
+        assert resp is None
+
+    def test_relaxed_match(self, loader):
+        resp = loader.match(
+            "GET",
+            "https://graph.microsoft.com/v1.0/places/microsoft.graph.room?$select=differentField",
+            relaxed=True,
+        )
+        assert resp is not None
+        assert resp.status == 200
+
+
+class TestHARResponseParsing:
+    def test_json_body_parsed(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        resp = loader.entries[0].response
+        assert isinstance(resp.body, dict)
+        assert resp.body["access_token"].startswith("eyJ")
+
+    def test_response_headers(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        resp = loader.entries[0].response
+        assert resp.headers["Content-Type"] == "application/json"
+
+    def test_request_headers(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        req = loader.entries[1].request
+        assert req.headers["Accept"] == "application/json"
+
+
+class TestHAREntryListing:
+    def test_list_entries(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        listing = loader.list_entries()
+        assert len(listing) == 2
+        assert listing[0]["method"] == "POST"
+        assert listing[1]["method"] == "GET"
+
+    def test_event_entries_empty(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        assert loader.event_entries() == []
+
+
+class TestHARComments:
+    def test_entry_comment(self):
+        loader = HARLoader.from_file(CAPTURES / "microsoft_calendar_oauth_flow.har")
+        assert "OAuth" in loader.entries[0].comment


### PR DESCRIPTION
## Summary — Sprint 1 Day 3

HAR loader and first synthetic capture fixtures.

### `simulator/har_loader.py`
- Parses HAR 1.2 JSON into typed `HAREntry` objects
- Request→response matching: exact URL match + relaxed (path-only) mode
- Simulated event support (`_simulated_event` flag for listener injection)
- Robust error handling for malformed HAR files
- Entry listing for CLI display

### Synthetic HAR Fixtures (2 of 6)
- `microsoft_calendar_oauth_flow.har` — OAuth client_credentials token request + rooms query
- `microsoft_calendar_event_list.har` — Current calendar view + future calendar view

## Test results
- **191 tests** (16 new)
- **87% coverage**
- ruff clean

## Remaining for Sprint 1
- 4 more HAR fixtures (MS Calendar token refresh, 3x Daikin)
- Mock server (aiohttp)
- Simulator runner (trigger-flag state machine)
- Golden harness
- Docs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)