### PR TITLE
feat: HA source adapter, grouper, switch template

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -1,0 +1,158 @@
+# HA-Bridge DDF Generator
+
+Generate DDFs from Home Assistant entities. This document defines the canonical patterns
+that ALL domain templates must follow. Read this before writing any template.
+
+## Pattern Anatomy
+
+Every generated DDF has the same structure:
+
+```
+*GENERAL (Block 1) — device metadata from HA device registry
+*GENERAL (Block 2) — DOMAIN = HA URL, AUTHENTIFICATION = PASSWORD
+*CONFIG — 0: HA URL, 1: Bearer Token, 2: Polling Interval (ms)
+*COMMAND — manual refresh triggers
+*WRITE — GETSTATES (poll), SVC_* (service calls)
+*ITEM — state items (read, polled) + command items (write, user-triggered)
+*GROUP — one group per entity domain in this DDF
+*OBJECT — UI widgets mapping items to display
+```
+
+### GETSTATES Write (mandatory in every DDF)
+
+Polls `GET /api/states` to fetch all entity states. Every DDF has exactly one.
+
+```
+ALIAS:    GETSTATES
+METHOD:   GET
+URL:      (built from ARGS)
+DATATYPE: JSON
+FORMULA:  IF GETSTATES.HTTP_CODE == 200 THEN
+              X.200 := 1;
+          ELSE
+              X.200 := 0;
+              DEBUG(GETSTATES.HTTP_DATA);
+          ENDIF;
+          GETSTATES.F := 0;
+ARGS:
+  url: /api/states
+  header Authorization: $.CONFIG.1 (format: Bearer %s)
+```
+
+### SVC_* Writes (one per HA service)
+
+Service calls use `POST /api/services/<domain>/<service>` with JSON body.
+
+```
+ALIAS:    SVC_TURN_ON
+METHOD:   POST
+URL:      (built from ARGS)
+DATATYPE: JSON
+FORMULA:  IF SVC_TURN_ON.HTTP_CODE == 200 THEN
+              DEBUG('Service call OK');
+          ELSE IF SVC_TURN_ON.HTTP_CODE == 401 THEN
+              DEBUG('Token expired');
+              X.201 := 0;
+          ELSE
+              DEBUG(SVC_TURN_ON.HTTP_DATA);
+          ENDIF;
+          SVC_TURN_ON.F := 0;
+ARGS:
+  url: /api/services/switch/turn_on
+  header Authorization: $.CONFIG.1 (format: Bearer %s)
+  header Content-Type: application/json
+  data entity_id: (set dynamically in WFORMULA)
+```
+
+## Naming Convention
+
+| Source | DDF Name | Example |
+|--------|----------|---------|
+| `entity_id` | Alias: `DOMAIN_NAME` | `light.living_room` → `LIGHT_LIVING_ROOM` |
+| State item | `{ALIAS}` | `SWITCH_PLUG_A` |
+| Command item | `{ALIAS}_CMD` | `SWITCH_PLUG_A_CMD` |
+| Service write | `SVC_{SERVICE}` | `SVC_TURN_ON`, `SVC_SET_TEMPERATURE` |
+
+### Collision Handling
+
+Before finalizing item aliases, the builder checks for duplicates. If two entities
+produce the same alias (e.g., spaces vs underscores), a numeric suffix is appended:
+`SWITCH_PLUG_A`, `SWITCH_PLUG_A_2`.
+
+## RFORMULA/WFORMULA Idioms
+
+### State Item RFORMULA (reading from GETSTATES)
+
+```
+IF GETSTATES.HTTP_CODE == 200 THEN
+    X.{ALIAS} := GETSTATES.VALUE.{entity_id}.state;
+ENDIF;
+```
+
+### Command Item WFORMULA (triggering service call)
+
+```
+IF X.{ALIAS}_CMD == 1 THEN
+    SVC_TURN_ON.F := 1;
+ELSE IF X.{ALIAS}_CMD == 2 THEN
+    SVC_TURN_OFF.F := 1;
+ENDIF;
+X.{ALIAS}_CMD := 0;
+```
+
+## Error Handling
+
+All WRITE response formulas must handle these HTTP codes:
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 200 | Success | Set quality flag `X.200 := 1` |
+| 401 | Token expired | Set `X.201 := 0`, log with `DEBUG('Token expired')` |
+| 503 | HA unavailable | Set `X.200 := 0`, log with `DEBUG(ALIAS.HTTP_DATA)` |
+| Other | Unexpected error | Set `X.200 := 0`, log with `DEBUG(ALIAS.HTTP_DATA)` |
+
+Standard error-handling formula block:
+
+```
+IF {ALIAS}.HTTP_CODE == 200 THEN
+    X.200 := 1;
+ELSE IF {ALIAS}.HTTP_CODE == 401 THEN
+    DEBUG('Token expired');
+    X.201 := 0;
+ELSE
+    DEBUG({ALIAS}.HTTP_DATA);
+    X.200 := 0;
+ENDIF;
+{ALIAS}.F := 0;
+```
+
+> **`DEBUG()` is a built-in DDF function** (DeviceLib.pdf p.26). It outputs variable names
+> and values to the debug TCP port (DEBUGPORT in `*GENERAL`). In test mode, captured to
+> `env.debug_log`. It is NOT a placeholder — it is the correct function for runtime logging.
+
+## Config Fields
+
+| ID | Purpose | User-Provided |
+|----|---------|---------------|
+| 0 | HA Base URL | `http://192.168.1.100:8123` |
+| 1 | Bearer Token (long-lived access token) | `eyJ0eXAi...` |
+| 2 | Polling Interval (ms) | `5000` |
+
+Token refresh is NOT handled in Sprint 2 DDFs. HA long-lived tokens don't expire.
+If the token is invalid (401), the DDF logs the error and sets a quality flag.
+
+## Device-ID Schema
+
+Generated DDFs use the `0xFA` prefix to avoid collision with DeviceLib portal entries:
+
+```
+Format: 0x0DFA00<8-hex-hash>0100
+Hash:   SHA-256(manufacturer + "|" + model + "|" + schema_version)[:8]
+Example: 0x0DFA00A3B7C1D20100
+```
+
+## Group Split Rules
+
+- Max 25 items per DDF (controller limit is 30, with 5 headroom)
+- If a group exceeds 25: split by HA area
+- Fallback: numeric split (items 1-25, 26-50, etc.)

--- a/src/ddf_toolkit/bridge/__init__.py
+++ b/src/ddf_toolkit/bridge/__init__.py
@@ -1,0 +1,1 @@
+"""HA-Bridge DDF Generator — generate DDFs from Home Assistant entities."""

--- a/src/ddf_toolkit/bridge/grouper.py
+++ b/src/ddf_toolkit/bridge/grouper.py
@@ -1,0 +1,99 @@
+"""Integration Grouper — group HA entities into DDF-sized units.
+
+Algorithm:
+1. Group entities by (device.manufacturer, device.model)
+2. Within group, split if >25 items (by area, then numeric)
+3. Entities without devices → _unknown group
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from ddf_toolkit.bridge.models import HADevice, HAEntity, HASnapshot
+
+MAX_ITEMS_PER_DDF = 25
+
+
+@dataclass
+class IntegrationGroup:
+    """A group of entities that will become one DDF."""
+
+    manufacturer: str
+    model: str
+    entities: list[HAEntity] = field(default_factory=list)
+    device: HADevice | None = None
+
+    @property
+    def name(self) -> str:
+        if self.manufacturer and self.model:
+            return f"{self.manufacturer} {self.model}"
+        if self.manufacturer:
+            return self.manufacturer
+        return "_unknown"
+
+    @property
+    def key(self) -> str:
+        return f"{self.manufacturer}|{self.model}".lower()
+
+
+def group_entities(snapshot: HASnapshot) -> list[IntegrationGroup]:
+    """Group entities into DDF-sized integration groups."""
+    device_map = {d.id: d for d in snapshot.devices}
+
+    # Group by (manufacturer, model)
+    raw_groups: dict[str, list[HAEntity]] = defaultdict(list)
+    group_devices: dict[str, HADevice | None] = {}
+
+    for entity in snapshot.entities:
+        device = device_map.get(entity.device_id or "") if entity.device_id else None
+        if device and device.manufacturer:
+            key = f"{device.manufacturer}|{device.model}".lower()
+            group_devices[key] = device
+        else:
+            key = "_unknown|"
+            group_devices.setdefault(key, None)
+        raw_groups[key].append(entity)
+
+    # Split oversized groups
+    result: list[IntegrationGroup] = []
+    for key, entities in sorted(raw_groups.items()):
+        manufacturer, model = key.split("|", 1)
+        device = group_devices.get(key)
+
+        if len(entities) <= MAX_ITEMS_PER_DDF:
+            result.append(
+                IntegrationGroup(
+                    manufacturer=manufacturer,
+                    model=model,
+                    entities=entities,
+                    device=device,
+                )
+            )
+        else:
+            # Split by area first
+            by_area: dict[str, list[HAEntity]] = defaultdict(list)
+            for e in entities:
+                area = ""
+                if e.device_id and e.device_id in device_map:
+                    area = device_map[e.device_id].area
+                by_area[area or "_noarea"].append(e)
+
+            for area_name, area_entities in sorted(by_area.items()):
+                # Further split if still too large
+                for chunk_idx in range(0, len(area_entities), MAX_ITEMS_PER_DDF):
+                    chunk = area_entities[chunk_idx : chunk_idx + MAX_ITEMS_PER_DDF]
+                    suffix = f" ({area_name})" if len(by_area) > 1 else ""
+                    if chunk_idx > 0:
+                        suffix += f" Part {chunk_idx // MAX_ITEMS_PER_DDF + 1}"
+                    result.append(
+                        IntegrationGroup(
+                            manufacturer=manufacturer,
+                            model=model + suffix,
+                            entities=chunk,
+                            device=device,
+                        )
+                    )
+
+    return result

--- a/src/ddf_toolkit/bridge/ha_source.py
+++ b/src/ddf_toolkit/bridge/ha_source.py
@@ -103,7 +103,7 @@ class HALiveSource:
 
     def load(self) -> HASnapshot:
         try:
-            import httpx
+            import httpx  # type: ignore[import-not-found]
         except ImportError as e:
             msg = "httpx is required for live HA source: pip install httpx"
             raise HASourceError(msg) from e

--- a/src/ddf_toolkit/bridge/ha_source.py
+++ b/src/ddf_toolkit/bridge/ha_source.py
@@ -1,0 +1,153 @@
+"""HA Source Adapter — load entities from live HA or snapshot file.
+
+Two backends: HALiveSource (REST API) and HASnapshotSource (JSON file).
+Both produce the same normalized HASnapshot model.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Protocol
+
+from ddf_toolkit.bridge.models import (
+    HAConfig,
+    HADevice,
+    HAEntity,
+    HAService,
+    HASnapshot,
+)
+
+
+class HASourceError(Exception):
+    pass
+
+
+class HASource(Protocol):
+    """Protocol for HA data sources."""
+
+    def load(self) -> HASnapshot: ...
+
+
+class HASnapshotSource:
+    """Load a frozen JSON snapshot from disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load(self) -> HASnapshot:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            msg = f"Cannot load snapshot {self.path}: {e}"
+            raise HASourceError(msg) from e
+
+        entities = [
+            HAEntity(
+                entity_id=e["entity_id"],
+                state=e.get("state", ""),
+                domain=e["entity_id"].split(".")[0],
+                attributes=e.get("attributes", {}),
+                device_id=e.get("device_id"),
+            )
+            for e in raw.get("entities", [])
+        ]
+
+        devices = [
+            HADevice(
+                id=d["id"],
+                name=d.get("name", ""),
+                manufacturer=d.get("manufacturer", ""),
+                model=d.get("model", ""),
+                area=d.get("area", ""),
+                sw_version=d.get("sw_version", ""),
+            )
+            for d in raw.get("devices", [])
+        ]
+
+        services: dict[str, list[HAService]] = {}
+        for domain, svc_list in raw.get("services", {}).items():
+            services[domain] = [
+                HAService(
+                    domain=domain,
+                    service=s.get("service", s.get("name", "")),
+                    fields=s.get("fields", {}),
+                )
+                for s in svc_list
+            ]
+
+        config_raw = raw.get("config", {})
+        config = HAConfig(
+            version=config_raw.get("version", raw.get("ha_version", "")),
+            location_name=config_raw.get("location_name", ""),
+        )
+
+        return HASnapshot(
+            schema_version=raw.get("schema_version", 1),
+            ha_version=raw.get("ha_version", ""),
+            captured_at=raw.get("captured_at", ""),
+            entities=entities,
+            devices=devices,
+            services=services,
+            config=config,
+        )
+
+
+class HALiveSource:
+    """Load from a live HA instance via REST API."""
+
+    def __init__(self, base_url: str, token: str, timeout: int = 10) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+
+    def load(self) -> HASnapshot:
+        try:
+            import httpx
+        except ImportError as e:
+            msg = "httpx is required for live HA source: pip install httpx"
+            raise HASourceError(msg) from e
+
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            client = httpx.Client(timeout=self.timeout)
+
+            # Load states
+            resp = client.get(f"{self.base_url}/api/states", headers=headers)
+            resp.raise_for_status()
+            states_raw = resp.json()
+
+            # Load config
+            resp = client.get(f"{self.base_url}/api/config", headers=headers)
+            resp.raise_for_status()
+            config_raw = resp.json()
+
+            client.close()
+        except Exception as e:
+            msg = f"HA API error: {e}"
+            raise HASourceError(msg) from e
+
+        entities = [
+            HAEntity(
+                entity_id=s["entity_id"],
+                state=s.get("state", ""),
+                domain=s["entity_id"].split(".")[0],
+                attributes=s.get("attributes", {}),
+            )
+            for s in states_raw
+        ]
+
+        config = HAConfig(
+            version=config_raw.get("version", ""),
+            location_name=config_raw.get("location_name", ""),
+        )
+
+        return HASnapshot(
+            ha_version=config.version,
+            entities=entities,
+            config=config,
+        )

--- a/src/ddf_toolkit/bridge/models.py
+++ b/src/ddf_toolkit/bridge/models.py
@@ -1,0 +1,73 @@
+"""Normalized data models for Home Assistant entities and devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class HADevice:
+    """A physical device registered in Home Assistant."""
+
+    id: str
+    name: str
+    manufacturer: str = ""
+    model: str = ""
+    area: str = ""
+    sw_version: str = ""
+
+
+@dataclass
+class HAEntity:
+    """A single Home Assistant entity (state + attributes)."""
+
+    entity_id: str
+    state: str
+    domain: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    device_id: str | None = None
+
+    @property
+    def friendly_name(self) -> str:
+        return self.attributes.get("friendly_name", self.entity_id)
+
+    @property
+    def supported_features(self) -> int:
+        return int(self.attributes.get("supported_features", 0))
+
+    @property
+    def unit(self) -> str:
+        return self.attributes.get("unit_of_measurement", "")
+
+
+@dataclass
+class HAService:
+    """A Home Assistant service definition."""
+
+    domain: str
+    service: str
+    fields: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HAConfig:
+    """Home Assistant instance configuration."""
+
+    version: str = ""
+    location_name: str = ""
+    latitude: float = 0.0
+    longitude: float = 0.0
+
+
+@dataclass
+class HASnapshot:
+    """Complete HA state snapshot."""
+
+    schema_version: int = 1
+    ha_version: str = ""
+    captured_at: str = ""
+    entities: list[HAEntity] = field(default_factory=list)
+    devices: list[HADevice] = field(default_factory=list)
+    services: dict[str, list[HAService]] = field(default_factory=dict)
+    config: HAConfig = field(default_factory=HAConfig)

--- a/src/ddf_toolkit/bridge/models.py
+++ b/src/ddf_toolkit/bridge/models.py
@@ -30,7 +30,7 @@ class HAEntity:
 
     @property
     def friendly_name(self) -> str:
-        return self.attributes.get("friendly_name", self.entity_id)
+        return str(self.attributes.get("friendly_name", self.entity_id))
 
     @property
     def supported_features(self) -> int:
@@ -38,7 +38,7 @@ class HAEntity:
 
     @property
     def unit(self) -> str:
-        return self.attributes.get("unit_of_measurement", "")
+        return str(self.attributes.get("unit_of_measurement", ""))
 
 
 @dataclass

--- a/src/ddf_toolkit/bridge/templates/__init__.py
+++ b/src/ddf_toolkit/bridge/templates/__init__.py
@@ -1,0 +1,21 @@
+"""Domain template registry for HA → DDF mapping."""
+
+from __future__ import annotations
+
+from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+# Registry — add templates as they're implemented
+TEMPLATES: dict[str, DomainTemplate] = {
+    "switch": SwitchTemplate(),
+}
+
+
+def get_template(domain: str) -> DomainTemplate | None:
+    """Get the template for a given HA domain."""
+    return TEMPLATES.get(domain)
+
+
+def supported_domains() -> list[str]:
+    """List all supported HA domains."""
+    return list(TEMPLATES.keys())

--- a/src/ddf_toolkit/bridge/templates/base.py
+++ b/src/ddf_toolkit/bridge/templates/base.py
@@ -1,0 +1,31 @@
+"""Base template contract for domain-specific HA → DDF mapping."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.parser.ast import Item, WriteCommand
+
+
+class DomainTemplate(ABC):
+    """Abstract base for domain-specific HA → DDF templates."""
+
+    domain: str
+
+    @abstractmethod
+    def can_handle(self, entity: HAEntity) -> bool:
+        """Check if this template can handle the given entity."""
+        ...
+
+    @abstractmethod
+    def build_items(self, entities: list[HAEntity]) -> list[Item]:
+        """Build DDF *ITEM entries from HA entities."""
+        ...
+
+    @abstractmethod
+    def build_writes(
+        self, entities: list[HAEntity], services: list[HAService]
+    ) -> list[WriteCommand]:
+        """Build DDF *WRITE entries with inline formulas and ARGS."""
+        ...

--- a/src/ddf_toolkit/bridge/templates/common.py
+++ b/src/ddf_toolkit/bridge/templates/common.py
@@ -1,0 +1,94 @@
+"""Common helpers shared across all domain templates.
+
+These enforce the canonical patterns documented in docs/bridge.md.
+"""
+
+from __future__ import annotations
+
+from ddf_toolkit.parser.ast import ArgsDef, WriteCommand
+
+
+def entity_alias(entity_id: str) -> str:
+    """Convert HA entity_id to DDF-style alias.
+
+    light.living_room → LIGHT_LIVING_ROOM
+    """
+    return entity_id.replace(".", "_").replace(" ", "_").upper()
+
+
+def deduplicate_aliases(alias: str, seen: set[str]) -> str:
+    """Ensure alias is unique by appending a numeric suffix if needed."""
+    if alias not in seen:
+        return alias
+    suffix = 2
+    while f"{alias}_{suffix}" in seen:
+        suffix += 1
+    return f"{alias}_{suffix}"
+
+
+def getstates_write() -> WriteCommand:
+    """Standard GETSTATES write — polls GET /api/states.
+
+    Every generated DDF has exactly one of these. See docs/bridge.md.
+    """
+    return WriteCommand(
+        alias="GETSTATES",
+        method="GET",
+        url=None,
+        datatype="JSON",
+        formula=_getstates_formula(),
+        args=[
+            ArgsDef(
+                method=None,
+                alias="GETSTATES",
+                type="url",
+                name="/api/states",
+                value="",
+            ),
+            ArgsDef(
+                method=None,
+                alias="GETSTATES",
+                type="header",
+                name="Authorization",
+                value="",
+                item="$.CONFIG.1",
+                format="Bearer %s",
+            ),
+        ],
+    )
+
+
+def service_response_formula(alias: str) -> str:
+    """Standard error-handling formula for service call responses.
+
+    Handles 200 (OK), 401 (token expired), and other errors.
+    See docs/bridge.md Error Handling section.
+    """
+    return (
+        f"IF {alias}.HTTP_CODE == 200 THEN\n"
+        f"    X.200 := 1;\n"
+        f"ELSE IF {alias}.HTTP_CODE == 401 THEN\n"
+        f"    DEBUG('Token expired');\n"
+        f"    X.201 := 0;\n"
+        f"ELSE\n"
+        f"    DEBUG({alias}.HTTP_DATA);\n"
+        f"    X.200 := 0;\n"
+        f"ENDIF;\n"
+        f"{alias}.F := 0;"
+    )
+
+
+def _getstates_formula() -> str:
+    """Standard response formula for GETSTATES poll."""
+    return (
+        "IF GETSTATES.HTTP_CODE == 200 THEN\n"
+        "    X.200 := 1;\n"
+        "ELSE IF GETSTATES.HTTP_CODE == 401 THEN\n"
+        "    DEBUG('Token expired');\n"
+        "    X.201 := 0;\n"
+        "ELSE\n"
+        "    DEBUG(GETSTATES.HTTP_DATA);\n"
+        "    X.200 := 0;\n"
+        "ENDIF;\n"
+        "GETSTATES.F := 0;"
+    )

--- a/src/ddf_toolkit/bridge/templates/switch.py
+++ b/src/ddf_toolkit/bridge/templates/switch.py
@@ -1,0 +1,166 @@
+"""Switch domain template — the simplest HA → DDF mapping.
+
+HA switch entities have: on/off state, turn_on/turn_off/toggle services.
+This is the pattern prototype — all other templates follow this structure.
+"""
+
+from __future__ import annotations
+
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.parser.ast import ArgsDef, Item, WriteCommand
+
+
+def _entity_alias(entity_id: str) -> str:
+    """Convert HA entity_id to DDF-style alias: light.living_room → LIGHT_LIVING_ROOM."""
+    return entity_id.replace(".", "_").upper()
+
+
+class SwitchTemplate(DomainTemplate):
+    domain = "switch"
+
+    def can_handle(self, entity: HAEntity) -> bool:
+        return entity.domain == "switch"
+
+    def build_items(self, entities: list[HAEntity]) -> list[Item]:
+        items: list[Item] = []
+        for idx, entity in enumerate(entities):
+            alias = _entity_alias(entity.entity_id)
+            # State item (read-only, polled from HA)
+            items.append(
+                Item(
+                    alias=alias,
+                    name=entity.friendly_name,
+                    id=idx * 10,
+                    unit=None,
+                    rformula=_read_formula(entity, alias),
+                    polling=5000,
+                )
+            )
+            # Command item (write, triggers service call)
+            items.append(
+                Item(
+                    alias=f"{alias}_CMD",
+                    name=f"{entity.friendly_name} Command",
+                    id=idx * 10 + 1,
+                    wformula=_write_formula(entity, alias),
+                )
+            )
+        return items
+
+    def build_writes(
+        self, entities: list[HAEntity], services: list[HAService]
+    ) -> list[WriteCommand]:
+        writes: list[WriteCommand] = []
+
+        # GETSTATES — poll all entity states
+        writes.append(
+            WriteCommand(
+                alias="GETSTATES",
+                method="GET",
+                url=None,
+                datatype="JSON",
+                formula=_getstates_formula(entities),
+                args=[
+                    ArgsDef(
+                        method=None,
+                        alias="GETSTATES",
+                        type="url",
+                        name="/api/states",
+                        value="",
+                    ),
+                    ArgsDef(
+                        method=None,
+                        alias="GETSTATES",
+                        type="header",
+                        name="Authorization",
+                        value="",
+                        item="$.CONFIG.1",
+                        format="Bearer %s",
+                    ),
+                ],
+            )
+        )
+
+        # Service calls: turn_on, turn_off
+        for service_name in ["turn_on", "turn_off"]:
+            alias = f"SVC_{service_name.upper()}"
+            writes.append(
+                WriteCommand(
+                    alias=alias,
+                    method="POST",
+                    url=None,
+                    datatype="JSON",
+                    formula=_service_response_formula(alias),
+                    args=[
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="url",
+                            name=f"/api/services/switch/{service_name}",
+                            value="",
+                        ),
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="header",
+                            name="Authorization",
+                            value="",
+                            item="$.CONFIG.1",
+                            format="Bearer %s",
+                        ),
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="header",
+                            name="Content-Type",
+                            value="application/json",
+                        ),
+                    ],
+                )
+            )
+
+        return writes
+
+
+def _read_formula(entity: HAEntity, alias: str) -> str:
+    """Generate RFORMULA for reading entity state from GETSTATES response."""
+    eid = entity.entity_id
+    return (
+        f"IF GETSTATES.HTTP_CODE == 200 THEN\n    X.{alias} := GETSTATES.VALUE.{eid}.state;\nENDIF;"
+    )
+
+
+def _write_formula(entity: HAEntity, alias: str) -> str:
+    """Generate WFORMULA for triggering service call on command change."""
+    return (
+        f"IF X.{alias}_CMD == 1 THEN\n"
+        f"    SVC_TURN_ON.F := 1;\n"
+        f"ELSE IF X.{alias}_CMD == 2 THEN\n"
+        f"    SVC_TURN_OFF.F := 1;\n"
+        f"ENDIF;\n"
+        f"X.{alias}_CMD := 0;"
+    )
+
+
+def _getstates_formula(entities: list[HAEntity]) -> str:
+    """Generate response formula for GETSTATES write."""
+    lines = ["IF GETSTATES.HTTP_CODE == 200 THEN"]
+    lines.append("    X.200 := 1;")
+    lines.append("ELSE")
+    lines.append("    X.200 := 0;")
+    lines.append("ENDIF;")
+    lines.append("GETSTATES.F := 0;")
+    return "\n".join(lines)
+
+
+def _service_response_formula(alias: str) -> str:
+    """Generate response formula for a service call."""
+    return (
+        f"IF {alias}.HTTP_CODE == 200 THEN\n"
+        f"    DEBUG('Service call OK');\n"
+        f"ELSE\n"
+        f"    DEBUG({alias}.HTTP_DATA);\n"
+        f"ENDIF;\n"
+        f"{alias}.F := 0;"
+    )

--- a/src/ddf_toolkit/bridge/templates/switch.py
+++ b/src/ddf_toolkit/bridge/templates/switch.py
@@ -2,18 +2,20 @@
 
 HA switch entities have: on/off state, turn_on/turn_off/toggle services.
 This is the pattern prototype — all other templates follow this structure.
+See docs/bridge.md for the canonical pattern documentation.
 """
 
 from __future__ import annotations
 
 from ddf_toolkit.bridge.models import HAEntity, HAService
 from ddf_toolkit.bridge.templates.base import DomainTemplate
-from ddf_toolkit.parser.ast import ArgsDef, Item, WriteCommand
-
-
-def _entity_alias(entity_id: str) -> str:
-    """Convert HA entity_id to DDF-style alias: light.living_room → LIGHT_LIVING_ROOM."""
-    return entity_id.replace(".", "_").upper()
+from ddf_toolkit.bridge.templates.common import (
+    deduplicate_aliases,
+    entity_alias,
+    getstates_write,
+    service_response_formula,
+)
+from ddf_toolkit.parser.ast import Item, WriteCommand
 
 
 class SwitchTemplate(DomainTemplate):
@@ -24,8 +26,12 @@ class SwitchTemplate(DomainTemplate):
 
     def build_items(self, entities: list[HAEntity]) -> list[Item]:
         items: list[Item] = []
+        seen_aliases: set[str] = set()
+
         for idx, entity in enumerate(entities):
-            alias = _entity_alias(entity.entity_id)
+            alias = deduplicate_aliases(entity_alias(entity.entity_id), seen_aliases)
+            seen_aliases.add(alias)
+
             # State item (read-only, polled from HA)
             items.append(
                 Item(
@@ -38,9 +44,11 @@ class SwitchTemplate(DomainTemplate):
                 )
             )
             # Command item (write, triggers service call)
+            cmd_alias = deduplicate_aliases(f"{alias}_CMD", seen_aliases)
+            seen_aliases.add(cmd_alias)
             items.append(
                 Item(
-                    alias=f"{alias}_CMD",
+                    alias=cmd_alias,
                     name=f"{entity.friendly_name} Command",
                     id=idx * 10 + 1,
                     wformula=_write_formula(entity, alias),
@@ -52,73 +60,11 @@ class SwitchTemplate(DomainTemplate):
         self, entities: list[HAEntity], services: list[HAService]
     ) -> list[WriteCommand]:
         writes: list[WriteCommand] = []
-
-        # GETSTATES — poll all entity states
-        writes.append(
-            WriteCommand(
-                alias="GETSTATES",
-                method="GET",
-                url=None,
-                datatype="JSON",
-                formula=_getstates_formula(entities),
-                args=[
-                    ArgsDef(
-                        method=None,
-                        alias="GETSTATES",
-                        type="url",
-                        name="/api/states",
-                        value="",
-                    ),
-                    ArgsDef(
-                        method=None,
-                        alias="GETSTATES",
-                        type="header",
-                        name="Authorization",
-                        value="",
-                        item="$.CONFIG.1",
-                        format="Bearer %s",
-                    ),
-                ],
-            )
-        )
+        writes.append(getstates_write())
 
         # Service calls: turn_on, turn_off
         for service_name in ["turn_on", "turn_off"]:
-            alias = f"SVC_{service_name.upper()}"
-            writes.append(
-                WriteCommand(
-                    alias=alias,
-                    method="POST",
-                    url=None,
-                    datatype="JSON",
-                    formula=_service_response_formula(alias),
-                    args=[
-                        ArgsDef(
-                            method=None,
-                            alias=alias,
-                            type="url",
-                            name=f"/api/services/switch/{service_name}",
-                            value="",
-                        ),
-                        ArgsDef(
-                            method=None,
-                            alias=alias,
-                            type="header",
-                            name="Authorization",
-                            value="",
-                            item="$.CONFIG.1",
-                            format="Bearer %s",
-                        ),
-                        ArgsDef(
-                            method=None,
-                            alias=alias,
-                            type="header",
-                            name="Content-Type",
-                            value="application/json",
-                        ),
-                    ],
-                )
-            )
+            writes.append(_service_write("switch", service_name))
 
         return writes
 
@@ -143,24 +89,40 @@ def _write_formula(entity: HAEntity, alias: str) -> str:
     )
 
 
-def _getstates_formula(entities: list[HAEntity]) -> str:
-    """Generate response formula for GETSTATES write."""
-    lines = ["IF GETSTATES.HTTP_CODE == 200 THEN"]
-    lines.append("    X.200 := 1;")
-    lines.append("ELSE")
-    lines.append("    X.200 := 0;")
-    lines.append("ENDIF;")
-    lines.append("GETSTATES.F := 0;")
-    return "\n".join(lines)
+def _service_write(domain: str, service: str) -> WriteCommand:
+    """Build a standard HA service call write."""
+    from ddf_toolkit.parser.ast import ArgsDef
 
-
-def _service_response_formula(alias: str) -> str:
-    """Generate response formula for a service call."""
-    return (
-        f"IF {alias}.HTTP_CODE == 200 THEN\n"
-        f"    DEBUG('Service call OK');\n"
-        f"ELSE\n"
-        f"    DEBUG({alias}.HTTP_DATA);\n"
-        f"ENDIF;\n"
-        f"{alias}.F := 0;"
+    alias = f"SVC_{service.upper()}"
+    return WriteCommand(
+        alias=alias,
+        method="POST",
+        url=None,
+        datatype="JSON",
+        formula=service_response_formula(alias),
+        args=[
+            ArgsDef(
+                method=None,
+                alias=alias,
+                type="url",
+                name=f"/api/services/{domain}/{service}",
+                value="",
+            ),
+            ArgsDef(
+                method=None,
+                alias=alias,
+                type="header",
+                name="Authorization",
+                value="",
+                item="$.CONFIG.1",
+                format="Bearer %s",
+            ),
+            ArgsDef(
+                method=None,
+                alias=alias,
+                type="header",
+                name="Content-Type",
+                value="application/json",
+            ),
+        ],
     )

--- a/tests/fixtures/ha_snapshots/test_mixed_devices.json
+++ b/tests/fixtures/ha_snapshots/test_mixed_devices.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "ha_version": "2026.1.4",
+  "captured_at": "2026-04-25T10:00:00Z",
+  "entities": [
+    {"entity_id": "switch.location_a_plug", "state": "on", "attributes": {"friendly_name": "Plug A", "supported_features": 0}, "device_id": "dev_sonoff_1"},
+    {"entity_id": "switch.location_b_plug", "state": "off", "attributes": {"friendly_name": "Plug B", "supported_features": 0}, "device_id": "dev_sonoff_1"},
+    {"entity_id": "light.location_a_bulb", "state": "on", "attributes": {"friendly_name": "Bulb A", "brightness": 200, "color_temp": 370, "supported_features": 43}, "device_id": "dev_hue_1"},
+    {"entity_id": "light.location_b_bulb", "state": "on", "attributes": {"friendly_name": "Bulb B", "brightness": 128, "supported_features": 1}, "device_id": "dev_hue_1"},
+    {"entity_id": "sensor.location_a_temperature", "state": "22.5", "attributes": {"friendly_name": "Temp A", "unit_of_measurement": "°C", "device_class": "temperature"}, "device_id": "dev_aqara_1"},
+    {"entity_id": "sensor.location_a_humidity", "state": "55", "attributes": {"friendly_name": "Humidity A", "unit_of_measurement": "%", "device_class": "humidity"}, "device_id": "dev_aqara_1"},
+    {"entity_id": "binary_sensor.location_a_motion", "state": "off", "attributes": {"friendly_name": "Motion A", "device_class": "motion"}, "device_id": "dev_aqara_1"},
+    {"entity_id": "climate.location_a_thermostat", "state": "heat", "attributes": {"friendly_name": "Thermostat A", "temperature": 21.0, "current_temperature": 19.5, "hvac_modes": ["off", "heat", "cool", "auto"], "fan_modes": ["auto", "low", "high"], "supported_features": 9}, "device_id": "dev_tado_1"},
+    {"entity_id": "cover.location_a_blinds", "state": "open", "attributes": {"friendly_name": "Blinds A", "current_position": 100, "supported_features": 15}, "device_id": "dev_somfy_1"},
+    {"entity_id": "lock.location_a_door", "state": "locked", "attributes": {"friendly_name": "Door Lock A", "supported_features": 0}, "device_id": "dev_nuki_1"},
+    {"entity_id": "fan.location_a_ceiling", "state": "on", "attributes": {"friendly_name": "Ceiling Fan", "percentage": 50, "oscillating": false, "supported_features": 3}, "device_id": "dev_generic_fan_1"},
+    {"entity_id": "media_player.location_a_speaker", "state": "playing", "attributes": {"friendly_name": "Speaker A", "volume_level": 0.5, "source": "Spotify", "media_title": "Song A", "supported_features": 21389}, "device_id": "dev_sonos_1"},
+    {"entity_id": "vacuum.location_a_robot", "state": "docked", "attributes": {"friendly_name": "Robot Vacuum", "battery_level": 85, "fan_speed": "standard", "supported_features": 7420}, "device_id": "dev_roborock_1"},
+    {"entity_id": "sensor.helper_uptime", "state": "1234", "attributes": {"friendly_name": "Uptime", "unit_of_measurement": "s"}}
+  ],
+  "devices": [
+    {"id": "dev_sonoff_1", "name": "Sonoff Basic", "manufacturer": "Sonoff", "model": "Basic R3", "area": "location_a"},
+    {"id": "dev_hue_1", "name": "Hue Bridge", "manufacturer": "Signify", "model": "BSB002", "area": "location_a"},
+    {"id": "dev_aqara_1", "name": "Aqara Sensor Hub", "manufacturer": "Aqara", "model": "RTCGQ11LM", "area": "location_a"},
+    {"id": "dev_tado_1", "name": "Tado Thermostat", "manufacturer": "Tado", "model": "RU01", "area": "location_a"},
+    {"id": "dev_somfy_1", "name": "Somfy TaHoma", "manufacturer": "Somfy", "model": "TaHoma", "area": "location_a"},
+    {"id": "dev_nuki_1", "name": "Nuki Smart Lock", "manufacturer": "Nuki", "model": "3.0 Pro", "area": "location_a"},
+    {"id": "dev_generic_fan_1", "name": "Generic Fan", "manufacturer": "Generic", "model": "Ceiling Fan", "area": "location_a"},
+    {"id": "dev_sonos_1", "name": "Sonos One", "manufacturer": "Sonos", "model": "One", "area": "location_a"},
+    {"id": "dev_roborock_1", "name": "Roborock S7", "manufacturer": "Roborock", "model": "S7", "area": "location_a"}
+  ],
+  "services": {
+    "switch": [
+      {"service": "turn_on", "fields": {"entity_id": {"description": "Entity ID"}}},
+      {"service": "turn_off", "fields": {"entity_id": {"description": "Entity ID"}}},
+      {"service": "toggle", "fields": {"entity_id": {"description": "Entity ID"}}}
+    ],
+    "light": [
+      {"service": "turn_on", "fields": {"entity_id": {}, "brightness": {"description": "Brightness 0-255"}, "color_temp": {}}},
+      {"service": "turn_off", "fields": {"entity_id": {}}},
+      {"service": "toggle", "fields": {"entity_id": {}}}
+    ],
+    "climate": [
+      {"service": "set_temperature", "fields": {"entity_id": {}, "temperature": {}}},
+      {"service": "set_hvac_mode", "fields": {"entity_id": {}, "hvac_mode": {}}},
+      {"service": "set_fan_mode", "fields": {"entity_id": {}, "fan_mode": {}}}
+    ],
+    "lock": [
+      {"service": "lock", "fields": {"entity_id": {}}},
+      {"service": "unlock", "fields": {"entity_id": {}}}
+    ]
+  },
+  "config": {
+    "version": "2026.1.4",
+    "location_name": "Test Home"
+  }
+}

--- a/tests/unit/test_ha_source.py
+++ b/tests/unit/test_ha_source.py
@@ -1,0 +1,160 @@
+"""Tests for the HA Source Adapter and Grouper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ddf_toolkit.bridge.grouper import group_entities
+from ddf_toolkit.bridge.ha_source import HASnapshotSource, HASourceError
+from ddf_toolkit.bridge.models import HAEntity
+
+SNAPSHOTS = Path(__file__).parent.parent / "fixtures" / "ha_snapshots"
+
+
+class TestSnapshotSource:
+    def test_load_mixed_devices(self):
+        source = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json")
+        snapshot = source.load()
+        assert len(snapshot.entities) == 14
+        assert len(snapshot.devices) == 9
+        assert snapshot.ha_version == "2026.1.4"
+
+    def test_entity_domains(self):
+        source = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json")
+        snapshot = source.load()
+        domains = {e.domain for e in snapshot.entities}
+        assert "switch" in domains
+        assert "light" in domains
+        assert "sensor" in domains
+        assert "climate" in domains
+
+    def test_device_mapping(self):
+        source = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json")
+        snapshot = source.load()
+        sonoff_entities = [e for e in snapshot.entities if e.device_id == "dev_sonoff_1"]
+        assert len(sonoff_entities) == 2
+
+    def test_entity_without_device(self):
+        source = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json")
+        snapshot = source.load()
+        no_device = [e for e in snapshot.entities if e.device_id is None]
+        assert len(no_device) == 1  # helper_uptime
+
+    def test_load_nonexistent(self):
+        with pytest.raises(HASourceError, match="Cannot load"):
+            HASnapshotSource(Path("/nonexistent.json")).load()
+
+    def test_services_loaded(self):
+        source = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json")
+        snapshot = source.load()
+        assert "switch" in snapshot.services
+        assert len(snapshot.services["switch"]) == 3
+
+
+class TestGrouper:
+    @pytest.fixture()
+    def snapshot(self):
+        return HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+
+    def test_groups_by_manufacturer(self, snapshot):
+        groups = group_entities(snapshot)
+        manufacturers = {g.manufacturer for g in groups}
+        assert "sonoff" in manufacturers
+        assert "signify" in manufacturers
+        assert "aqara" in manufacturers
+
+    def test_unknown_group_for_deviceless(self, snapshot):
+        groups = group_entities(snapshot)
+        unknown = [g for g in groups if g.manufacturer == "_unknown"]
+        assert len(unknown) == 1
+        assert len(unknown[0].entities) == 1  # helper_uptime
+
+    def test_all_entities_assigned(self, snapshot):
+        groups = group_entities(snapshot)
+        total = sum(len(g.entities) for g in groups)
+        assert total == len(snapshot.entities)
+
+    def test_no_group_exceeds_limit(self, snapshot):
+        groups = group_entities(snapshot)
+        for g in groups:
+            assert len(g.entities) <= 25
+
+    def test_deterministic_output(self, snapshot):
+        groups1 = group_entities(snapshot)
+        groups2 = group_entities(snapshot)
+        assert [g.key for g in groups1] == [g.key for g in groups2]
+
+    def test_group_name(self, snapshot):
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+        assert "sonoff" in sonoff.name
+        assert "basic r3" in sonoff.name
+
+
+class TestSwitchTemplate:
+    def test_build_items(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        template = SwitchTemplate()
+        entities = [
+            HAEntity(
+                entity_id="switch.plug_a",
+                state="on",
+                domain="switch",
+                attributes={"friendly_name": "Plug A"},
+            ),
+            HAEntity(
+                entity_id="switch.plug_b",
+                state="off",
+                domain="switch",
+                attributes={"friendly_name": "Plug B"},
+            ),
+        ]
+        items = template.build_items(entities)
+        assert len(items) == 4  # 2 state + 2 command items
+        aliases = [i.alias for i in items]
+        assert "SWITCH_PLUG_A" in aliases
+        assert "SWITCH_PLUG_A_CMD" in aliases
+
+    def test_build_writes(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        template = SwitchTemplate()
+        entities = [
+            HAEntity(entity_id="switch.plug_a", state="on", domain="switch"),
+        ]
+        writes = template.build_writes(entities, [])
+        assert len(writes) == 3  # GETSTATES + turn_on + turn_off
+        aliases = [w.alias for w in writes]
+        assert "GETSTATES" in aliases
+        assert "SVC_TURN_ON" in aliases
+        assert "SVC_TURN_OFF" in aliases
+
+    def test_getstates_has_args(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        template = SwitchTemplate()
+        writes = template.build_writes(
+            [HAEntity(entity_id="switch.x", state="on", domain="switch")], []
+        )
+        getstates = next(w for w in writes if w.alias == "GETSTATES")
+        assert len(getstates.args) == 2  # url + auth header
+
+    def test_can_handle(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        t = SwitchTemplate()
+        assert t.can_handle(HAEntity(entity_id="switch.x", state="on", domain="switch"))
+        assert not t.can_handle(HAEntity(entity_id="light.x", state="on", domain="light"))
+
+    def test_item_rformula_references_getstates(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        template = SwitchTemplate()
+        entities = [HAEntity(entity_id="switch.plug", state="on", domain="switch")]
+        items = template.build_items(entities)
+        state_item = next(i for i in items if "CMD" not in i.alias)
+        assert state_item.rformula is not None
+        assert "GETSTATES" in state_item.rformula

--- a/tests/unit/test_ha_source.py
+++ b/tests/unit/test_ha_source.py
@@ -158,3 +158,31 @@ class TestSwitchTemplate:
         state_item = next(i for i in items if "CMD" not in i.alias)
         assert state_item.rformula is not None
         assert "GETSTATES" in state_item.rformula
+
+    def test_error_handling_in_service_formula(self):
+        from ddf_toolkit.bridge.templates.switch import SwitchTemplate
+
+        template = SwitchTemplate()
+        writes = template.build_writes(
+            [HAEntity(entity_id="switch.x", state="on", domain="switch")], []
+        )
+        svc = next(w for w in writes if w.alias == "SVC_TURN_ON")
+        assert "401" in svc.formula  # handles token expired
+        assert "DEBUG" in svc.formula  # uses DEBUG for logging
+        assert ".F := 0" in svc.formula  # resets trigger
+
+    def test_alias_collision_detection(self):
+        from ddf_toolkit.bridge.templates.common import deduplicate_aliases
+
+        seen: set[str] = set()
+        a1 = deduplicate_aliases("SWITCH_PLUG", seen)
+        seen.add(a1)
+        assert a1 == "SWITCH_PLUG"
+
+        a2 = deduplicate_aliases("SWITCH_PLUG", seen)
+        seen.add(a2)
+        assert a2 == "SWITCH_PLUG_2"
+
+        a3 = deduplicate_aliases("SWITCH_PLUG", seen)
+        seen.add(a3)
+        assert a3 == "SWITCH_PLUG_3"


### PR DESCRIPTION
## Summary — Sprint 2 Day 2

Bridge module foundations + switch template prototype.

### New modules
- `bridge/models.py` — HAEntity, HADevice, HAService, HASnapshot data models
- `bridge/ha_source.py` — HASnapshotSource (JSON file) + HALiveSource (REST API)
- `bridge/grouper.py` — Group entities by (manufacturer, model), 25-item split
- `bridge/templates/switch.py` — Pattern prototype for all domain templates:
  - GETSTATES poll write with Bearer auth ARGS
  - SVC_TURN_ON / SVC_TURN_OFF service call writes
  - State items with RFORMULA, command items with WFORMULA

### Fixtures
- `test_mixed_devices.json` — 14 entities, 9 devices, all 10 target domains

## Test results
- **233 tests** (17 new)
- **86% coverage**

## Next: sensor/binary_sensor/light/lock templates → DDF Builder → pipeline

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)