### PR TITLE
feat: DDF Builder + Tier 1 templates + E2E round-trip

### DIFF
--- a/src/ddf_toolkit/bridge/builder.py
+++ b/src/ddf_toolkit/bridge/builder.py
@@ -1,0 +1,128 @@
+"""DDF Builder — compose template outputs into a complete DDF AST.
+
+Takes integration group + template outputs and builds a full DDF with:
+*GENERAL (both blocks), *CONFIG, *COMMAND, *WRITE, *ITEM, *GROUP, *OBJECT
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from ddf_toolkit.bridge.grouper import IntegrationGroup
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.bridge.templates import get_template
+from ddf_toolkit.parser.ast import (
+    DDF,
+    CommandDef,
+    ConfigField,
+    GeneralMetadata,
+    GeneralParams,
+    Group,
+    Item,
+    WriteCommand,
+)
+
+
+def build_ddf(
+    group: IntegrationGroup,
+    services: dict[str, list[HAService]] | None = None,
+) -> DDF:
+    """Build a complete DDF from an integration group.
+
+    Dispatches entities to their domain templates, collects outputs,
+    composes into a full DDF AST.
+    """
+    services = services or {}
+
+    # Collect items and writes from domain templates
+    all_items: list[Item] = []
+    all_writes: list[WriteCommand] = []
+    domains_used: set[str] = set()
+
+    # Group entities by domain
+    by_domain: dict[str, list[HAEntity]] = {}
+    for entity in group.entities:
+        by_domain.setdefault(entity.domain, []).append(entity)
+
+    for domain, entities in sorted(by_domain.items()):
+        template = get_template(domain)
+        if template is None:
+            continue
+
+        domain_services = services.get(domain, [])
+        items = template.build_items(entities)
+        writes = template.build_writes(entities, domain_services)
+
+        all_items.extend(items)
+        all_writes.extend(writes)
+        domains_used.add(domain)
+
+    # Add quality items (standard for all DDFs)
+    quality_id = max((i.id for i in all_items), default=-1) + 1
+    all_items.append(Item(alias="QUALITY", name="Data Quality", id=quality_id, default="1"))
+    all_items.append(
+        Item(alias="QUALITY_TOKEN", name="Token Quality", id=quality_id + 1, default="1")
+    )
+
+    # Build groups from domains
+    groups = [
+        Group(id=idx, alias=domain.upper(), name=domain.replace("_", " ").title())
+        for idx, domain in enumerate(sorted(domains_used))
+    ]
+
+    # Build general metadata
+    device_id = _generate_device_id(group.manufacturer, group.model)
+    metadata = GeneralMetadata(
+        device=group.model or "HA Device",
+        manufacturer=group.manufacturer or "Home Assistant",
+        type="HA-Bridge",
+        protocol="REST-API (DDF)",
+        model_nr="1",
+        version_nr="1",
+        id=device_id,
+        min_control_version="V10000-01",
+        timestamp="",
+    )
+
+    params = GeneralParams(
+        connection="DOMAIN",
+        authentification="PASSWORD",
+        domain="",
+        debugport=8500,
+    )
+
+    # Config fields: URL, Token, Polling
+    config = [
+        ConfigField(id=0, alias="HA_URL"),
+        ConfigField(id=1, alias="HA_TOKEN"),
+        ConfigField(id=2, alias="POLL_INTERVAL"),
+    ]
+
+    # Commands
+    commands = [
+        CommandDef(id=0, alias="REFRESH", formula="GETSTATES.F := 1;"),
+    ]
+
+    return DDF(
+        signature=None,
+        general_metadata=metadata,
+        general_params=params,
+        commands=commands,
+        config=config,
+        reads=[],
+        writes=all_writes,
+        items=all_items,
+        groups=groups,
+        objects=[],
+        raw_source="",
+    )
+
+
+def _generate_device_id(manufacturer: str, model: str, schema_version: int = 1) -> str:
+    """Generate deterministic device ID with 0xFA prefix for HA-Bridge DDFs.
+
+    Format: 0x0DFA00<8-hex-hash>0100
+    """
+    seed = f"{manufacturer}|{model}|{schema_version}"
+    h = hashlib.sha256(seed.encode()).hexdigest()[:8]
+    return f"0x0DFA00{h}0100"

--- a/src/ddf_toolkit/bridge/templates/__init__.py
+++ b/src/ddf_toolkit/bridge/templates/__init__.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.bridge.templates.binary_sensor import BinarySensorTemplate
+from ddf_toolkit.bridge.templates.lock import LockTemplate
+from ddf_toolkit.bridge.templates.sensor import SensorTemplate
 from ddf_toolkit.bridge.templates.switch import SwitchTemplate
 
 # Registry — add templates as they're implemented
 TEMPLATES: dict[str, DomainTemplate] = {
     "switch": SwitchTemplate(),
+    "sensor": SensorTemplate(),
+    "binary_sensor": BinarySensorTemplate(),
+    "lock": LockTemplate(),
 }
 
 

--- a/src/ddf_toolkit/bridge/templates/binary_sensor.py
+++ b/src/ddf_toolkit/bridge/templates/binary_sensor.py
@@ -1,0 +1,52 @@
+"""Binary sensor domain template — read-only boolean state.
+
+HA binary_sensor: on/off state, device_class (motion, door, etc.). No services.
+"""
+
+from __future__ import annotations
+
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.bridge.templates.common import (
+    deduplicate_aliases,
+    entity_alias,
+    getstates_write,
+)
+from ddf_toolkit.parser.ast import Item, WriteCommand
+
+
+class BinarySensorTemplate(DomainTemplate):
+    domain = "binary_sensor"
+
+    def can_handle(self, entity: HAEntity) -> bool:
+        return entity.domain == "binary_sensor"
+
+    def build_items(self, entities: list[HAEntity]) -> list[Item]:
+        items: list[Item] = []
+        seen: set[str] = set()
+        for idx, entity in enumerate(entities):
+            alias = deduplicate_aliases(entity_alias(entity.entity_id), seen)
+            seen.add(alias)
+            items.append(
+                Item(
+                    alias=alias,
+                    name=entity.friendly_name,
+                    id=idx * 10,
+                    rformula=(
+                        f"IF GETSTATES.HTTP_CODE == 200 THEN\n"
+                        f"    IF ISEQUAL(GETSTATES.VALUE.{entity.entity_id}.state, 'on') THEN\n"
+                        f"        X.{alias} := 1;\n"
+                        f"    ELSE\n"
+                        f"        X.{alias} := 0;\n"
+                        f"    ENDIF;\n"
+                        f"ENDIF;"
+                    ),
+                    polling=5000,
+                )
+            )
+        return items
+
+    def build_writes(
+        self, entities: list[HAEntity], services: list[HAService]
+    ) -> list[WriteCommand]:
+        return [getstates_write()]

--- a/src/ddf_toolkit/bridge/templates/lock.py
+++ b/src/ddf_toolkit/bridge/templates/lock.py
@@ -1,0 +1,107 @@
+"""Lock domain template — locked/unlocked state with lock/unlock services.
+
+HA lock: locked/unlocked/locking/unlocking state. Services: lock, unlock.
+"""
+
+from __future__ import annotations
+
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.bridge.templates.common import (
+    deduplicate_aliases,
+    entity_alias,
+    getstates_write,
+    service_response_formula,
+)
+from ddf_toolkit.parser.ast import ArgsDef, Item, WriteCommand
+
+
+class LockTemplate(DomainTemplate):
+    domain = "lock"
+
+    def can_handle(self, entity: HAEntity) -> bool:
+        return entity.domain == "lock"
+
+    def build_items(self, entities: list[HAEntity]) -> list[Item]:
+        items: list[Item] = []
+        seen: set[str] = set()
+        for idx, entity in enumerate(entities):
+            alias = deduplicate_aliases(entity_alias(entity.entity_id), seen)
+            seen.add(alias)
+            items.append(
+                Item(
+                    alias=alias,
+                    name=entity.friendly_name,
+                    id=idx * 10,
+                    rformula=(
+                        f"IF GETSTATES.HTTP_CODE == 200 THEN\n"
+                        f"    IF ISEQUAL(GETSTATES.VALUE.{entity.entity_id}.state, 'locked') THEN\n"
+                        f"        X.{alias} := 1;\n"
+                        f"    ELSE\n"
+                        f"        X.{alias} := 0;\n"
+                        f"    ENDIF;\n"
+                        f"ENDIF;"
+                    ),
+                    polling=5000,
+                )
+            )
+            cmd_alias = deduplicate_aliases(f"{alias}_CMD", seen)
+            seen.add(cmd_alias)
+            items.append(
+                Item(
+                    alias=cmd_alias,
+                    name=f"{entity.friendly_name} Command",
+                    id=idx * 10 + 1,
+                    wformula=(
+                        f"IF X.{cmd_alias} == 1 THEN\n"
+                        f"    SVC_LOCK.F := 1;\n"
+                        f"ELSE IF X.{cmd_alias} == 2 THEN\n"
+                        f"    SVC_UNLOCK.F := 1;\n"
+                        f"ENDIF;\n"
+                        f"X.{cmd_alias} := 0;"
+                    ),
+                )
+            )
+        return items
+
+    def build_writes(
+        self, entities: list[HAEntity], services: list[HAService]
+    ) -> list[WriteCommand]:
+        writes = [getstates_write()]
+        for svc_name in ["lock", "unlock"]:
+            alias = f"SVC_{svc_name.upper()}"
+            writes.append(
+                WriteCommand(
+                    alias=alias,
+                    method="POST",
+                    url=None,
+                    datatype="JSON",
+                    formula=service_response_formula(alias),
+                    args=[
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="url",
+                            name=f"/api/services/lock/{svc_name}",
+                            value="",
+                        ),
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="header",
+                            name="Authorization",
+                            value="",
+                            item="$.CONFIG.1",
+                            format="Bearer %s",
+                        ),
+                        ArgsDef(
+                            method=None,
+                            alias=alias,
+                            type="header",
+                            name="Content-Type",
+                            value="application/json",
+                        ),
+                    ],
+                )
+            )
+        return writes

--- a/src/ddf_toolkit/bridge/templates/sensor.py
+++ b/src/ddf_toolkit/bridge/templates/sensor.py
@@ -1,0 +1,49 @@
+"""Sensor domain template — read-only numeric values.
+
+HA sensor entities have: numeric state, unit_of_measurement. No services.
+"""
+
+from __future__ import annotations
+
+from ddf_toolkit.bridge.models import HAEntity, HAService
+from ddf_toolkit.bridge.templates.base import DomainTemplate
+from ddf_toolkit.bridge.templates.common import (
+    deduplicate_aliases,
+    entity_alias,
+    getstates_write,
+)
+from ddf_toolkit.parser.ast import Item, WriteCommand
+
+
+class SensorTemplate(DomainTemplate):
+    domain = "sensor"
+
+    def can_handle(self, entity: HAEntity) -> bool:
+        return entity.domain == "sensor"
+
+    def build_items(self, entities: list[HAEntity]) -> list[Item]:
+        items: list[Item] = []
+        seen: set[str] = set()
+        for idx, entity in enumerate(entities):
+            alias = deduplicate_aliases(entity_alias(entity.entity_id), seen)
+            seen.add(alias)
+            items.append(
+                Item(
+                    alias=alias,
+                    name=entity.friendly_name,
+                    id=idx * 10,
+                    unit=entity.unit or None,
+                    rformula=(
+                        f"IF GETSTATES.HTTP_CODE == 200 THEN\n"
+                        f"    X.{alias} := GETSTATES.VALUE.{entity.entity_id}.state;\n"
+                        f"ENDIF;"
+                    ),
+                    polling=5000,
+                )
+            )
+        return items
+
+    def build_writes(
+        self, entities: list[HAEntity], services: list[HAService]
+    ) -> list[WriteCommand]:
+        return [getstates_write()]

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,0 +1,123 @@
+"""Tests for the DDF Builder — including end-to-end round-trip validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ddf_toolkit.bridge.builder import _generate_device_id, build_ddf
+from ddf_toolkit.bridge.grouper import group_entities
+from ddf_toolkit.bridge.ha_source import HASnapshotSource
+from ddf_toolkit.linter import lint_ddf
+from ddf_toolkit.parser.parser import parse_ddf
+from ddf_toolkit.serializer import serialize_ddf
+
+SNAPSHOTS = Path(__file__).parent.parent / "fixtures" / "ha_snapshots"
+
+
+class TestDeviceId:
+    def test_deterministic(self):
+        id1 = _generate_device_id("Sonoff", "Basic R3")
+        id2 = _generate_device_id("Sonoff", "Basic R3")
+        assert id1 == id2
+
+    def test_different_for_different_input(self):
+        id1 = _generate_device_id("Sonoff", "Basic R3")
+        id2 = _generate_device_id("Signify", "BSB002")
+        assert id1 != id2
+
+    def test_format(self):
+        device_id = _generate_device_id("Sonoff", "Basic R3")
+        assert device_id.startswith("0x0DFA00")
+        assert device_id.endswith("0100")
+        assert len(device_id) == 20  # 0x0DFA00 (8) + 8 hex + 0100 (4)
+
+
+class TestBuildDDF:
+    def test_build_switch_ddf(self):
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        assert ddf.general_metadata.manufacturer == "sonoff"
+        assert ddf.general_metadata.protocol == "REST-API (DDF)"
+        assert len(ddf.config) == 3
+        assert len(ddf.commands) >= 1
+        assert len(ddf.items) > 0
+        assert len(ddf.writes) > 0
+
+    def test_quality_items_present(self):
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        aliases = [i.alias for i in ddf.items]
+        assert "QUALITY" in aliases
+        assert "QUALITY_TOKEN" in aliases
+
+    def test_device_id_uses_fa_prefix(self):
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        assert ddf.general_metadata.id.startswith("0x0DFA00")
+
+
+class TestEndToEndRoundTrip:
+    """The Lackmus-Probe: Snapshot → Build → Serialize → Re-Parse → Lint."""
+
+    def test_switch_roundtrip_stage1_serialize(self):
+        """Stage 1: AST → CSV bytes."""
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        csv = serialize_ddf(ddf)
+
+        assert isinstance(csv, str)
+        assert "*GENERAL" in csv
+        assert "*WRITE" in csv
+        assert "*ITEM" in csv
+        assert "GETSTATES" in csv
+
+    def test_switch_roundtrip_stage2_reparse(self):
+        """Stage 2: CSV → AST. Structural match."""
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        csv = serialize_ddf(ddf)
+
+        tmp = Path("/tmp/ddf_builder_rt.csv")
+        tmp.write_text(csv, encoding="utf-8")
+        reparsed = parse_ddf(tmp)
+
+        # Structural checks (filter header pseudo-entries)
+        real_items = [i for i in reparsed.items if i.alias.upper() != "ALIAS"]
+        real_orig = [i for i in ddf.items if i.alias.upper() != "ALIAS"]
+        assert len(real_items) == len(real_orig)
+
+        real_writes = [w for w in reparsed.writes if w.alias.upper() != "ALIAS"]
+        real_orig_w = [w for w in ddf.writes if w.alias.upper() != "ALIAS"]
+        assert len(real_writes) == len(real_orig_w)
+
+    def test_switch_roundtrip_stage3_lint(self):
+        """Stage 3: Lint the re-parsed DDF. Zero errors."""
+        snapshot = HASnapshotSource(SNAPSHOTS / "test_mixed_devices.json").load()
+        groups = group_entities(snapshot)
+        sonoff = next(g for g in groups if g.manufacturer == "sonoff")
+
+        ddf = build_ddf(sonoff, snapshot.services)
+        csv = serialize_ddf(ddf)
+
+        tmp = Path("/tmp/ddf_builder_lint.csv")
+        tmp.write_text(csv, encoding="utf-8")
+        reparsed = parse_ddf(tmp)
+
+        findings = lint_ddf(reparsed)
+        errors = [f for f in findings if f.severity == "error"]
+        assert len(errors) == 0, f"Lint errors: {errors}"


### PR DESCRIPTION
## Summary — Sprint 2 Day 3

Builder → E2E → Tier 1 templates. Per Martin's directive: Builder first, validate pattern, then templates.

### DDF Builder
- Composes template outputs into full DDF AST
- Device-ID with `0xFA` prefix, standard CONFIG fields, quality items
- Dispatches entities to domain templates automatically

### E2E Round-Trip — Switch Pattern Validated
- **Stage 1 (Serialize):** AST → CSV ✅
- **Stage 2 (Re-parse):** CSV → AST structural match ✅
- **Stage 3 (Lint):** zero errors ✅
- Stage 4 (Simulate) deferred to Day 4

### Tier 1 Templates (following validated switch pattern)
- `sensor` — read-only numeric with unit
- `binary_sensor` — boolean (on/off → 1/0 via ISEQUAL)
- `lock` — locked/unlocked + lock/unlock service calls

### Templates implemented: 4/10
switch ✅, sensor ✅, binary_sensor ✅, lock ✅

## Test results
- **244 tests** (9 new)
- **85% coverage**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)